### PR TITLE
Drop support for PHP 8.1, Add support for PHP 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         }
     },
     "require": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+        "php": "^8.1",
         "laminas/laminas-filter": "^2.13.1",
         "laminas/laminas-form": "^3.1",
         "laminas/laminas-inputfilter": "^2.13",


### PR DESCRIPTION
I'm stuck because I have a dependency and I need PHP 8.4.  Please consider allowing all versions of PHP 8.